### PR TITLE
Action should be optional

### DIFF
--- a/src/Xacmlphp/Decider.php
+++ b/src/Xacmlphp/Decider.php
@@ -52,7 +52,7 @@ class Decider
      *
      * @return bool
      */
-    public function evaluate(Subject $subject, PolicySet $policySet, Action $action)
+    public function evaluate(Subject $subject, PolicySet $policySet, Action $action = null)
     {
         // get the subject's attributes
         $this->setSubjectAttributes($subject->getAttributes());

--- a/src/Xacmlphp/Enforcer.php
+++ b/src/Xacmlphp/Enforcer.php
@@ -60,7 +60,7 @@ class Enforcer
      *
      * @return bool Allowed/not allowed status
      */
-    public function isAuthorized(Subject $subject, Resource $resource, Action $action)
+    public function isAuthorized(Subject $subject, Resource $resource, Action $action = null)
     {
         $decider = $this->getDecider();
         if ($decider === null) {


### PR DESCRIPTION
Not passing an Action object to the isAuthorized() function results in an error: 

`Catchable fatal error: Argument 3 passed to Xacmlphp\Enforcer::isAuthorized() must be an instance of Xacmlphp\Action, none given`

making the Action parameter optional solves this.